### PR TITLE
add split multi-byte char test (and single-line event test)

### DIFF
--- a/ssetests/tests_basic_parsing.go
+++ b/ssetests/tests_basic_parsing.go
@@ -115,12 +115,6 @@ func DoBasicParsingTests(t *T) {
 		t.RequireSpecificEvents(expected...)
 	})
 
-	// The following test is based on one that's in the js-eventsource unit tests. While it works there,
-	// it does not (cannot?) work in Ruby, and possibly some other platforms where there's no native
-	// "non-string binary data" type. On such platforms, the pieces of data being read from the stream
-	// are represented as strings, and any multi-byte character in a string must be complete or the
-	// string is invalid, so breaking a multi-byte character into pieces like this would cause an error.
-	// If that's true, we should probably delete this.
 	t.Run("multi-byte characters sent in single-byte pieces", func(t *T) {
 		t.StartSSEClient()
 		t.SendOnStreamInChunks("data: €豆腐\n\n", 1, time.Millisecond*20)

--- a/ssetests/tests_basic_parsing.go
+++ b/ssetests/tests_basic_parsing.go
@@ -1,6 +1,9 @@
 package ssetests
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 func DoBasicParsingTests(t *T) {
 	t.Run("one-line message in one chunk", func(t *T) {
@@ -118,9 +121,9 @@ func DoBasicParsingTests(t *T) {
 	// are represented as strings, and any multi-byte character in a string must be complete or the
 	// string is invalid, so breaking a multi-byte character into pieces like this would cause an error.
 	// If that's true, we should probably delete this.
-	// t.Run("multi-byte characters sent in single-byte pieces", func(t *T) {
-	// 	   t.StartSSEClient()
-	//     t.SendSplit("data: €豆腐\n\n", 1, time.Millisecond*20)
-	//     t.RequireSpecificEvents(e, EventMessage{Data: "€豆腐"})
-	// })
+	t.Run("multi-byte characters sent in single-byte pieces", func(t *T) {
+		t.StartSSEClient()
+		t.SendOnStreamInChunks("data: €豆腐\n\n", 1, time.Millisecond*20)
+		t.RequireSpecificEvents(EventMessage{Data: "€豆腐"})
+	})
 }

--- a/ssetests/tests_linefeeds.go
+++ b/ssetests/tests_linefeeds.go
@@ -29,6 +29,13 @@ func DoLinefeedTests(t *T) {
 
 	testWithTerminator := func(terminator string) func(t *T) {
 		return func(t *T) {
+			t.Run("one-line event", testInputParsing(
+				"data: event 1"+terminator+terminator,
+				[]EventMessage{
+					{Data: "event 1"},
+				},
+			))
+
 			t.Run("one-line event + two-line event", testInputParsing(
 				"data: event 1"+terminator+terminator+
 					"data: event 2 line 1"+terminator+


### PR DESCRIPTION
This adds a scenario to the SSE contract tests in which there are multi-byte UTF8 characters that are sent in single-byte chunks, to expose problems like [sc-133195](https://app.shortcut.com/launchdarkly/story/133195/python-sdk-can-fail-to-process-stream-data-due-to-incomplete-multi-byte-character-unexpected-end-of-data-error) where the SSE client inappropriately tries to decode the UTF8 data before it has read a full line.

I know that this test fails for the Python implementation, as discussed in the linked story. I suspect it will also fail on at least one other platform, Ruby, because Ruby does not have good support for reading streams as bytes rather than as strings.

Unrelated: I also improved the coverage in the "linefeeds" test group by adding a test where we send a single-line event using each of the supported line terminators. We already had a single-line event test in the "basic parsing" group, but that only covered `\n` line terminators. I added this because I saw a problem in our Python SSE implementation that I suspected would make it fail if `\r` line terminators were used for multi-line events but not for single-line events, and this new test verified that that was true.