### PR TITLE
don't require error on reconnection test where it's not relevant

### DIFF
--- a/ssetests/tests_reconnection.go
+++ b/ssetests/tests_reconnection.go
@@ -156,7 +156,6 @@ func DoReconnectionTests(t *T) {
 		t.RequireSpecificEvents(EventMessage{ID: "abc", Data: "Hello"})
 
 		t.BreakStreamConnection()
-		t.RequireError()
 
 		t.AwaitNewConnectionToStream()
 		t.SendOnStream("data: We meet again\n\n")


### PR DESCRIPTION
SSE client implementations don't necessarily report the closing of a stream as an error, so when the test really just wants to know "did the client reconnect to the stream after we closed it", the test should limit its expectations to that.