### PR TITLE
re-fix previous fix to reconnect test logic

### DIFF
--- a/ssetests/tests_reconnection.go
+++ b/ssetests/tests_reconnection.go
@@ -161,6 +161,7 @@ func DoReconnectionTests(t *ldtest.T) {
 		client.RequireSpecificEvents(t, EventMessage{ID: "abc", Data: "Hello"})
 
 		stream1.BreakConnection()
+		client.IgnoreErrorHere() // client may or may not signal an error; we only care about the events here
 
 		stream2 := server.AwaitConnection(t)
 		stream2.Send("data: We meet again\n\n")


### PR DESCRIPTION
As I found as soon as I tried to rerun the tests against the Go eventsource, my previous fix was wrong because it introduced an expectation that the client would definitely _not_ report an error there— since we were trying to read an event. What we really want is to see either 1. the event or 2. an error which we don't care about, followed by the event. So I've extended the API a little to make an expectation like this easier.

I considered adding some kind of "push back a message that we just read" method, to support more general cases of "we might see X, or we might see Y then X", but I think that's probably overkill.