### PR TITLE
fix service request schema and docs for "listen" command

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,13 +1,15 @@
 # How to deploy this tool
 
-In a CI job for an SSE implementatin, the most convenient way to run the test suite is by invoking the `downloader/run.sh` script, which downloads the compiled executable and runs it. You can download this script directly from GitHub and pipe it to `bash` or `sh`. This is similar to how tools such as Goreleaser are normally run. You must set `VERSION` to the desired version of the tool, and `PARAMS` to the command-line parameters.
+In a CI job for an SSE implementation, the most convenient way to run the test suite is by invoking the `downloader/run.sh` script, which downloads the compiled executable and runs it. You can download this script directly from GitHub and pipe it to `bash` or `sh`. This is similar to how tools such as Goreleaser are normally run. You must set `VERSION` to the desired version of the tool, and `PARAMS` to the command-line parameters.
 
 ```shell
-curl -s https://raw.githubusercontent.com/launchdarkly/sse-test-harness/master/downloader/run.sh \
-  | VERSION=v1 PARAMS="--url http://localhost:8000" sh
+curl -s https://raw.githubusercontent.com/launchdarkly/sse-test-harness/v2.0.0/downloader/run.sh \
+  | VERSION=v2 PARAMS="--url http://localhost:8000" sh
 ```
 
-You can specify an exact version string such as `v1.0.0` in `VERSION`, but it is better to specify only a major version so that you will automatically get any backward-compatible improvements in the test harness.
+In this example, `v2.0.0` is the version of the `run.sh` script to use. If there are any significant changes to the script, there will be a new major version, to ensure that CI jobs pinned to previous versions will not fail.
+
+The `VERSION=v2` setting is what determines what version of the actual tests to use. It's best to specify only a major version so that you will automatically get any backward-compatible improvements in the test harness-- as long as you keep in mind that this might cause a build to fail that previously passed, if a more sensitive test is added (that is, if the test harness now detects a kind of noncompliance with the SSE spec that it did not previously check for). If you want to make sure your builds will never break due to such an improvement in the tests, you can instead pin to a specific version string such as `VERSION=v2.0.0`, but be aware that this could mean a bug is overlooked.
 
 There is also a published Docker image that you can run, `ldcircleci/sse-contract-tests`. Again you can specify either a specific version or a major version, such as `ldcircleci/sse-contract-tests:1`. In order for this to work, the test harness must be able to see the test service and vice versa, so you must remember to expose the callback port on the test harness container-- and you must tell Docker to use either host networking (if the test service is running locally outside of Docker) or a shared network (if the test service is running in Docker).
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -36,8 +36,28 @@ If any parameters are invalid, return HTTP `400`.
 
 A `POST` request to the resource that was returned by "Create stream" means the test harness wants to do something to an existing SSE client instance. The request body is a JSON object which can be one of the following:
 
-* `{ "command": "listen", "type": "<EVENT TYPE>" }` - The SSE client should be ready to receive events with the type `EVENT TYPE`. This will only be sent if the test service has the `"event-type-listeners"` capability.
-* `{ "command": "restart" }` - The SSE client should disconnect and reconnect with the same stream URL. This will only be sent if the test service has the `"restart"` capability.
+#### `listen` command
+
+```json
+{
+  "command": "listen",
+  "listen": {
+    "type": "<EVENT TYPE>"
+  }
+}
+```
+
+This means the SSE client should be ready to receive events with the type `EVENT TYPE`. This will only be sent if the test service has the `"event-type-listeners"` capability.
+
+#### `restart` command
+
+```json
+{
+  "command": "restart"
+}
+```
+
+This means SSE client should disconnect and reconnect with the same stream URL. This will only be sent if the test service has the `"restart"` capability.
 
 Return any HTTP `2xx` status, `400` for an unrecognized command, or `404` if there is no such stream.
 

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -17,8 +17,8 @@ type CreateStreamParams struct {
 }
 
 type CommandParams struct {
-	Command string `json:"command"`
-	Listen  *ListenParams
+	Command string        `json:"command"`
+	Listen  *ListenParams `json:"listen"`
 }
 
 type ListenParams struct {


### PR DESCRIPTION
As part of bringing the design of sse-contract-tests more into line with sdk-test-harness, the parameters for any command like "listen" that has its own parameters were moved into a sub-object (this is desirable because service implementations that are strongly typed can use a single schema with optional properties for all command requests). But the docs weren't updated, and the capitalization was wrong on the `listen` property.

Note that the only SSE test service implementation that uses `listen`, `js-eventsource`, is still using the old schema. Moving that parameter was technically a breaking change, so the next release of sse-contract-tests will be 2.0.0 to avoid breaking any current CI. Any CI jobs that are using the download/run script correctly will continue to get the latest 1.x version till we tell them otherwise.