### PR TITLE
add test for field without colon

### DIFF
--- a/ssetests/tests_basic_parsing.go
+++ b/ssetests/tests_basic_parsing.go
@@ -122,7 +122,16 @@ func DoBasicParsingTests(t *ldtest.T) {
 	})
 
 	t.Run("field with no colon", func(t *ldtest.T) {
-		// a line that says only "data" should be equivalent to "data:"
+		// A line that says only "data" should be equivalent to "data:". Here we'll send two
+		// events as follows:
+		//
+		//     data
+		//
+		//     data
+		//     data
+		//
+		// The first of those should translate into an event with empty data. The second is an
+		// event with a single newline in the data, just as it would if each "data" was "data:".
 		_, stream, client := NewStreamAndSSEClient(t)
 		stream.Send("data\n\ndata\ndata\n\n")
 		client.RequireSpecificEvents(t,

--- a/ssetests/tests_basic_parsing.go
+++ b/ssetests/tests_basic_parsing.go
@@ -121,6 +121,16 @@ func DoBasicParsingTests(t *ldtest.T) {
 		client.RequireSpecificEvents(t, EventMessage{Type: " greeting", Data: " Hello"})
 	})
 
+	t.Run("field with no colon", func(t *ldtest.T) {
+		// a line that says only "data" should be equivalent to "data:"
+		_, stream, client := NewStreamAndSSEClient(t)
+		stream.Send("data\n\ndata\ndata\n\n")
+		client.RequireSpecificEvents(t,
+			EventMessage{Data: ""},
+			EventMessage{Data: "\n"},
+		)
+	})
+
 	t.Run("multi-byte characters", func(t *ldtest.T) {
 		_, stream, client := NewStreamAndSSEClient(t)
 		stream.Send("data: €豆腐\n\n")


### PR DESCRIPTION
This is one of those spec compliance issues that (currently) does not matter for LaunchDarkly usage, because our stream service doesn't ever send such a field, but it's still best to handle it correctly.