### PR TITLE
Use newer goreleaser to generate arm64 builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-GORELEASER_VERSION=v0.141.0
+GORELEASER_VERSION=v0.175.0
 GORELEASER_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) bash -s -- --rm-dist
 
 GOLANGCI_LINT_VERSION=v1.43.0


### PR DESCRIPTION
I'm not entirely sure the versioning constraints between our configured version of `Go` and `goreleaser` so I used the latest `goreleaser` that seemed to be using the same version of `Go` as we are. Tested a dry run in our releasing tool and verified that arm64 builds are being created and that the naming of the artifact matches `uname -m` for our downloader script.