### PR TITLE
Add contract tests for empty/missing Location headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 dist
 sse-contract-tests
+.idea

--- a/ssetests/tests_http_behavior.go
+++ b/ssetests/tests_http_behavior.go
@@ -48,8 +48,6 @@ func DoHTTPBehaviorTests(t *ldtest.T) {
 		// 2) Keep using the current URL without emitting an error
 		for _, action := range []string{"empty", "missing"} {
 			t.Run(fmt.Sprintf("client handles %s Location header with %d status", action, status), func(t *ldtest.T) {
-				t.RequireCapability("empty-or-missing-location")
-
 				headers := make(http.Header)
 				if action == "empty" {
 					headers.Set("Location", "")

--- a/ssetests/testsuite.go
+++ b/ssetests/testsuite.go
@@ -12,6 +12,7 @@ var AllCapabilities = []string{ //nolint:gochecknoglobals
 	"post",
 	"read-timeout",
 	"report",
+	"empty-or-missing-location",
 }
 
 func RunTestSuite(

--- a/ssetests/testsuite.go
+++ b/ssetests/testsuite.go
@@ -12,7 +12,6 @@ var AllCapabilities = []string{ //nolint:gochecknoglobals
 	"post",
 	"read-timeout",
 	"report",
-	"empty-or-missing-location",
 }
 
 func RunTestSuite(


### PR DESCRIPTION
While implementing redirect handling for the Rust eventsource-client, I needed to implement logic to handle missing/empty Location headers.

It would be undesirable for a client to enter an infinite loop if presented with `Location: ` or no Location header at all. Therefore, these tests assert that the client returns an error in both cases.

I put it behind a capability flag because I'm not sure that all clients implement this defensive functionality. 

The Go eventsource client does pass these tests, and specifically for 301s does even have a helpful error string:
```
2022/03/16 15:00:44.710944 [HTTP behavior/client handles empty Location header with 301 status]: Failed to start stream: Get "http://localhost:8111/endpoints/156": 301 response missing Location header
```
(for 307s it just says `error 307`)