### PR TITLE
Update skipped test output to a lighter shade of blue

### DIFF
--- a/framework/ldtest/test_logger.go
+++ b/framework/ldtest/test_logger.go
@@ -10,11 +10,11 @@ import (
 	"github.com/fatih/color"
 )
 
-var consoleTestErrorColor = color.New(color.FgYellow)              //nolint:gochecknoglobals
-var consoleTestFailedColor = color.New(color.FgRed)                //nolint:gochecknoglobals
-var consoleTestSkippedColor = color.New(color.Faint, color.FgBlue) //nolint:gochecknoglobals
-var consoleDebugOutputColor = color.New(color.Faint)               //nolint:gochecknoglobals
-var allTestsPassedColor = color.New(color.FgGreen)                 //nolint:gochecknoglobals
+var consoleTestErrorColor = color.New(color.FgYellow) //nolint:gochecknoglobals
+var consoleTestFailedColor = color.New(color.FgRed)   //nolint:gochecknoglobals
+var consoleTestSkippedColor = color.New(color.FgBlue) //nolint:gochecknoglobals
+var consoleDebugOutputColor = color.New(color.Faint)  //nolint:gochecknoglobals
+var allTestsPassedColor = color.New(color.FgGreen)    //nolint:gochecknoglobals
 
 type TestLogger interface {
 	TestStarted(id TestID)


### PR DESCRIPTION
Currently the "faint" variant of blue for skipped tests is unreadable for me. I'm not sure how much of this is due to my red/green colorblindness.

This PR updates the color to remove the "faint" attribute.

Original (black background, what I see):
<img width="554" alt="Screen Shot 2022-03-18 at 12 17 29 PM" src="https://user-images.githubusercontent.com/93554727/159070502-cd062756-8699-4a9d-8d2a-a0096d9bc3bb.png">

Updated (black background):
<img width="647" alt="Screen Shot 2022-03-18 at 12 17 46 PM" src="https://user-images.githubusercontent.com/93554727/159070488-9447e932-3358-4a72-93ed-926075128e31.png">

Updated (white background):
<img width="554" alt="Screen Shot 2022-03-18 at 12 20 23 PM" src="https://user-images.githubusercontent.com/93554727/159070480-c7e67974-81e3-4e08-8b64-7d03099da853.png">

I realize others may have different color terminals, but I figured black & white are two of the most common.

