### PR TITLE
ci: use draft releases to support immutable GitHub releases

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
   publish-release:
     needs: manual-publish
-    if: ${{ inputs.publish_release }}
+    if: ${{ format('{0}', inputs.publish_release) == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'The tag to upload release artifacts to (e.g., v1.2.3)'
+        description: 'The tag to upload release artifacts to an existing draft release (e.g., v1.2.3)'
         required: true
         type: string
+      publish_release:
+        description: 'Whether to publish (un-draft) the release after uploading artifacts'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   manual-publish:
@@ -36,5 +41,22 @@ jobs:
     - name: Upload Release Artifacts
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ inputs.tag }}
       run: |
-        gh release upload ${{ inputs.tag }} ./dist/*.tar.gz ./dist/*.zip --clobber
+        gh release upload "${TAG_NAME}" ./dist/*.tar.gz ./dist/*.zip --clobber
+
+  publish-release:
+    needs: manual-publish
+    if: ${{ inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,26 +15,22 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4
+      # Create any releases first, then create tags, and then optionally create any new PRs.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: main
+          skip-github-pull-request: true
 
-  create-tag:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
+      # Need the repository content to be able to create and push a tag.
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        if: ${{ steps.release.outputs.release_created == 'true' }}
 
       - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
@@ -47,8 +43,16 @@ jobs:
             git push origin "${TAG_NAME}"
           fi
 
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: main
+          skip-github-release: true
+
   release-sdk-test-harness:
-    needs: ['release-please', 'create-tag']
+    needs: ['release-please']
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,9 +21,51 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: main
 
-  release-sdk-test-harness:
+  create-tag:
     needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+  release-sdk-test-harness:
+    needs: ['release-please', 'create-tag']
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: ['release-please', 'release-sdk-test-harness']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,13 +1,14 @@
 {
   "bootstrap-sha": "a8f0b39d9b0f619e9474fc27714e0182b0d3b4d6",
-  "packages" : {
-    "." : {
-      "release-type" : "go",
-      "bump-minor-pre-major" : true,
-      "versioning" : "default",
-      "include-component-in-tag" : false,
-      "draft" : true,
-      "extra-files" : [
+  "packages": {
+    ".": {
+      "release-type": "go",
+      "bump-minor-pre-major": true,
+      "versioning": "default",
+      "include-component-in-tag": false,
+      "draft": true,
+      "force-tag-creation": true,
+      "extra-files": [
         "main.go"
       ]
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "bump-minor-pre-major" : true,
       "versioning" : "default",
       "include-component-in-tag" : false,
+      "draft" : true,
       "extra-files" : [
         "main.go"
       ]


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI-only changes; no application code or tests affected.

**Related issues**

Supports the org-wide migration to immutable GitHub releases. Once a release is published, it can no longer be modified, which breaks workflows that upload artifacts after release-please creates and publishes the release.

**Describe the solution you've provided**

This repo uploads compiled Go binaries to the GitHub release via goreleaser, so a draft-then-publish pattern is required. Three files are changed:

1. **`release-please-config.json`** — Added `"draft": true` so release-please creates draft (unpublished) releases. Also added `"force-tag-creation": true` (not yet supported by the release-please action, but included so it takes effect automatically once a supporting version is available). Minor whitespace normalization.
2. **`release-please.yml`** — Refactored to use a **split release-please** pattern (matching the `ld-relay` reference implementation):
   - Release-please is called **twice** within the `release-please` job. The first call uses `skip-github-pull-request: true` to only create releases (not PRs). If a release is created, the job checks out the repo and creates/pushes the git tag inline (since release-please skips tag creation for drafts). The second call uses `skip-github-release: true` to only create/update PRs, and only runs if no release was created. This ordering ensures the tag exists before release-please checks whether a release PR is still needed.
   - `release-sdk-test-harness` depends only on `release-please`.
   - New `publish-release` job un-drafts the release after all artifact jobs complete.
   - Pinned to `googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38` (v4.4.0), replacing the previous `google-github-actions` namespace.
3. **`manual-publish.yml`** — Adds a `publish_release` boolean input (default `true`) and a `publish-release` job. Also fixes a script injection risk by moving `${{ inputs.tag }}` into an env var for the `gh release upload` step. Updated `tag` input description to clarify it references an existing draft release.

**Key points for review:**

- `publish-release.needs` in `release-please.yml` includes `release-sdk-test-harness` — this is the only job that uploads artifacts. Verify this is the complete set.
- Tag names are passed via `env:` blocks in all `run:` steps to prevent script injection.
- `${{ github.repository }}` is safe to use inline (controlled by GitHub, not user input).
- No changes to `release.yml` — artifact upload logic is unchanged.
- `force-tag-creation` in `release-please-config.json` is a no-op today. Confirm it does not cause errors with the current release-please version.
- The `publish_release` condition in `manual-publish.yml` uses `${{ inputs.publish_release }}` — for `workflow_dispatch`, boolean inputs may arrive as strings. Verify this behaves correctly when set to `false`.

**Describe alternatives you've considered**

Could keep using mutable releases, but the org has enabled immutable releases and this is the standard migration pattern (matching `ld-relay` v8 reference implementation).

**Additional context**

This repo does not use SLSA attestation, so no attestation migration was needed. Unlike attestation-only repos (which can publish releases directly since `actions/attest@v4` doesn't modify releases), this repo needs draft releases because goreleaser uploads binaries as release assets after the release is created.

### Updates since last revision

- Replaced the separate `create-tag` job with inline tag creation steps within the `release-please` job, following the split release-please pattern from `ld-relay` commit `1581de9`.
- Release-please is now called twice: first to create releases only (`skip-github-pull-request: true`), then to create PRs only (`skip-github-release: true`) — ensuring the git tag exists before release-please evaluates whether a new release PR is needed.
- Pinned release-please action to `googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38` (v4.4.0).
- `release-sdk-test-harness` now depends only on `release-please` (removed `create-tag` dependency).

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes release automation order (release creation, tag creation, and publishing) and could break tagging/publishing if conditions or permissions are misconfigured, but it’s confined to CI workflows.
> 
> **Overview**
> Updates release automation to support *immutable GitHub releases* by using a **draft-then-publish** flow.
> 
> `release-please` is reworked to create draft releases first, create/push the corresponding git tag when a release is created, and only run the PR-creation path when no release was created; a new job then publishes (un-drafts) the release after the artifact workflow completes.
> 
> `manual-publish` gains an optional `publish_release` input and follow-up job to publish the release after uploading assets, and hardens `gh release upload` by passing the tag via an env var. `release-please-config.json` now sets `draft: true` (and `force-tag-creation: true`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e5311cf37ee0ea2268ef4dfc667baed32f5355b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->