### PR TITLE
ci: add permissions to caller job and upgrade release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       # Create any releases first, then create tags, and then optionally create any new PRs.
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
             git push origin "${TAG_NAME}"
           fi
 
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         if: ${{ steps.release.outputs.release_created != 'true' }}
         id: release-prs
         with:
@@ -53,6 +53,8 @@ jobs:
 
   release-sdk-test-harness:
     needs: ['release-please']
+    permissions:
+      contents: write
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/release.yml
     with:


### PR DESCRIPTION
## Summary
Fixes Release Please `startup_failure` by adding explicit `permissions` to the `release-sdk-test-harness` caller job and upgrading release-please-action from v4 to v5.

## Review & Testing Checklist for Human
- [ ] Verify the release-please workflow runs without startup_failure on next push to main
- [ ] Confirm release.yml's `contents: write` permission is sufficient for goreleaser publishing

### Notes
Same fix pattern as dotnet-core PR #241. The caller job needs explicit permissions because the reusable workflow (release.yml) declares `permissions: { contents: write }` which exceeds the restricted org defaults.

Link to Devin session: https://app.devin.ai/sessions/54e32482848742c19ebf9c374efdc833
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the release automation workflow and permissions, which can affect tagging/release creation if the new `release-please-action` behavior or GitHub token scopes differ. Changes are confined to CI but impact the main release pipeline.
> 
> **Overview**
> Upgrades `googleapis/release-please-action` from v4.4.0 to v5.0.0 for both the release creation and PR creation steps in `release-please.yml`.
> 
> Adds explicit `permissions: contents: write` to the `release-sdk-test-harness` reusable-workflow caller job so it can run `release.yml` without hitting restricted default token permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b3bd01927392c0b8a36a5b8713dc44a12683c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->