### PR TITLE
feat: add payload-size-stress-testable capability and test sweep

### DIFF
--- a/docs/optional_features.md
+++ b/docs/optional_features.md
@@ -55,6 +55,19 @@ Implementations of the `EventSource` API in browsers always start with no `Last-
 
 If this capability is enabled, the test harness will expect that any non-null and non-empty string it specifies in the `lastEventId` property of the client configuration will be copied into the `Last-Event-Id` header in the client's initial request, and treated as if it had been received as an `id:` in a previous event.
 
+## Payload size stress testing (capability `"payload-size-stress-testable"`)
+
+This means that the SSE client implementation is willing to be exercised with a sweep of `data:` payload sizes to catch buffer-mismatch stalls.
+
+Some SSE client implementations (or the HTTP stacks they run on top of) exhibit long stalls when the caller-side read buffer is smaller than an intermediate wrapping layer's buffer. In one observed case, a .NET SSE client using a 1024-byte `StreamReader` on top of MAUI Android's `AndroidMessageHandler` — which silently wraps the response body in a `BufferedStream` with a 4096-byte default buffer — stalled 60 to 90 seconds delivering payloads in the ~1 KiB to ~4 KiB range. The root cause was that `BufferedStream` over-drained the underlying Java `InputStream` on the first read, then blocked on a subsequent read waiting for the next chunk of data (which, on an SSE keepalive-driven connection, doesn't arrive until the next server-side heartbeat).
+
+If this capability is enabled, the test harness will send events at a variety of `data:` payload sizes chosen to sit near common buffer-size boundaries (1 KiB, 4 KiB, 8 KiB, plus larger sizes up to 1 MiB) and verify that each event is delivered to the test service within a short time budget. Any stall in the client's read loop will trip a fast timeout and fail the test.
+
+This capability is opt-in for two reasons:
+
+1. The sweep is a stress / robustness test, not a spec-conformance test. An SSE implementation can be fully spec-compliant without passing it.
+2. Implementations with a latent buffer-mismatch behavior that isn't immediately fixable can defer opting in until they've validated the sweep, avoiding a surprise CI failure.
+
 ## Sending a POST request (capability `"post"`)
 
 This means that the caller can tell the SSE client to send a `POST` request instead of a `GET` request, and specify the request body.

--- a/docs/optional_features.md
+++ b/docs/optional_features.md
@@ -61,12 +61,13 @@ This means that the SSE client implementation is willing to be exercised with a 
 
 Some SSE client implementations (or the HTTP stacks they run on top of) exhibit long stalls when the caller-side read buffer is smaller than an intermediate wrapping layer's buffer. In one observed case, a .NET SSE client using a 1024-byte `StreamReader` on top of MAUI Android's `AndroidMessageHandler` — which silently wraps the response body in a `BufferedStream` with a 4096-byte default buffer — stalled 60 to 90 seconds delivering payloads in the ~1 KiB to ~4 KiB range. The root cause was that `BufferedStream` over-drained the underlying Java `InputStream` on the first read, then blocked on a subsequent read waiting for the next chunk of data (which, on an SSE keepalive-driven connection, doesn't arrive until the next server-side heartbeat).
 
-If this capability is enabled, the test harness will send events at a variety of `data:` payload sizes chosen to sit near common buffer-size boundaries (1 KiB, 4 KiB, 8 KiB, plus larger sizes up to 1 MiB) and verify that each event is delivered to the test service within a short time budget. Any stall in the client's read loop will trip a fast timeout and fail the test.
+If this capability is enabled, the test harness will send events at every power of two from 1 byte through 128 MiB (2^0 to 2^27), plus one byte on either side of each power of two. Since most stream-wrapping layers choose buffer sizes at powers of two, the +/-1 probes catch sharp transitions in the failure mode. The test verifies that each event is delivered to the test service within a size-scaled time budget; any stall in the client's read loop will trip the timeout and fail the test.
 
-This capability is opt-in for two reasons:
+This capability is opt-in for three reasons:
 
 1. The sweep is a stress / robustness test, not a spec-conformance test. An SSE implementation can be fully spec-compliant without passing it.
 2. Implementations with a latent buffer-mismatch behavior that isn't immediately fixable can defer opting in until they've validated the sweep, avoiding a surprise CI failure.
+3. The largest sizes (up to 128 MiB) may exceed reasonable memory/bandwidth defaults for some test environments. Opting in signals that the test service is prepared to allocate and transfer payloads at that scale.
 
 ## Sending a POST request (capability `"post"`)
 

--- a/ssetests/testapi_sse_client.go
+++ b/ssetests/testapi_sse_client.go
@@ -184,6 +184,22 @@ func (c *SSEClient) RequireEvent(t *ldtest.T) EventMessage {
 	return *e
 }
 
+// RequireEventWithin waits for the SSE client to report an event, using an explicit timeout
+// instead of the default awaitMessageTimeout.
+//
+// Use this in tests where the expected arrival time is meaningfully shorter (or longer) than
+// the default -- for example, payload-size stress tests where a stalled read should fail fast
+// rather than eat the full default timeout.
+func (c *SSEClient) RequireEventWithin(t *ldtest.T, timeout time.Duration) EventMessage {
+	m, err := c.AwaitMessage(timeout)
+	require.NoError(t, err)
+	if m.Kind != "event" {
+		require.Fail(t, "received an unexpected message", "expected %q but got: %s", "event", m)
+	}
+	require.NotNil(t, m.Event, "missing object field \"event\" on expected \"event\" message")
+	return *m.Event
+}
+
 // RequireError waits for the SSE client in the test service to tell us that it received an error.
 //
 // The test fails and immediately exits if it times out without receiving anything, or if what we

--- a/ssetests/tests_payload_sizes.go
+++ b/ssetests/tests_payload_sizes.go
@@ -1,0 +1,79 @@
+package ssetests
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/launchdarkly/sse-contract-tests/framework/ldtest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// payloadSizeSweep is the set of `data:` payload lengths (in bytes) exercised by the
+// stress test. Sizes cluster around common buffer-size boundaries in the runtimes we've
+// observed:
+//
+//   - 1024 bytes  -- .NET's StreamReader default buffer
+//   - 4096 bytes  -- .NET's BufferedStream default buffer, page size on most systems
+//   - 8192 bytes  -- Okio Segment.SIZE (used by Android's OkHttp fork), doubled StreamReader
+//
+// The intent is to catch buffer-mismatch stalls where the caller-side read buffer is
+// smaller than an intermediate wrapping layer's buffer, causing the intermediate layer
+// to over-drain the underlying stream and force an extra blocking read.
+//
+// Sizes here are of the data string only; wire size = len("data: ") + size + len("\n\n").
+var payloadSizeSweep = []int{
+	1,
+	128,
+	512,
+	1023, 1024, 1025,
+	2048,
+	3999, 4094, 4096, 4098,
+	6144,
+	8189, 8192, 8195,
+	12288,
+	16384,
+	32768,
+	65536,
+	262144,
+	1048576,
+}
+
+// payloadArrivalTimeout is how long we wait for the test service to report the event.
+// Deliberately shorter than the default awaitMessageTimeout so that stalls fail fast
+// rather than eating the full default. For localhost test services this is more than
+// enough headroom; for very slow environments (real-device testing) it may need to
+// grow, but any stall of the class we're looking for (60+ seconds) will still trip it.
+const payloadArrivalTimeout = 3 * time.Second
+
+// DoPayloadSizeStressTests sends events at a variety of payload sizes to catch buffer-mismatch
+// stalls in SSE client implementations. This covers a class of bug where the client's read
+// buffer size interacts pathologically with an intermediate stream-wrapping layer, producing
+// long stalls when the payload lands in a specific size zone.
+//
+// This test is gated behind the "payload-size-stress-testable" capability because:
+//  1. It is a stress / robustness check, not a spec-conformance test.
+//  2. Some SSE implementations may have latent buffer-mismatch behavior that isn't
+//     immediately fixable, and we don't want their existing CI to fail on adoption.
+//     Teams opt in by declaring the capability once they've validated the sweep.
+//  3. The largest sizes (1 MiB) may exceed reasonable defaults for some environments;
+//     opting in signals that the test service is prepared to handle them.
+func DoPayloadSizeStressTests(t *ldtest.T) {
+	t.RequireCapability("payload-size-stress-testable")
+
+	for _, size := range payloadSizeSweep {
+		size := size // capture for closure
+		t.Run(fmt.Sprintf("payload of %d bytes is delivered promptly", size), func(t *ldtest.T) {
+			_, stream, client := NewStreamAndSSEClient(t)
+			data := strings.Repeat("x", size)
+			stream.Send("data: " + data + "\n\n")
+			actual := client.RequireEventWithin(t, payloadArrivalTimeout)
+			// Avoid printing megabytes of data on failure.
+			if actual.Data != data {
+				assert.Failf(t, "payload data did not match",
+					"expected %d bytes, got %d bytes", size, len(actual.Data))
+			}
+		})
+	}
+}

--- a/ssetests/tests_payload_sizes.go
+++ b/ssetests/tests_payload_sizes.go
@@ -2,6 +2,7 @@ package ssetests
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -11,41 +12,51 @@ import (
 )
 
 // payloadSizeSweep is the set of `data:` payload lengths (in bytes) exercised by the
-// stress test. Sizes cluster around common buffer-size boundaries in the runtimes we've
-// observed:
+// stress test. Generated as every power of two from 1 (2^0) through 128 MiB (2^27),
+// plus one byte on either side of each power of two. Duplicates (e.g. where pow+1
+// meets the next pow-1) are removed.
 //
-//   - 1024 bytes  -- .NET's StreamReader default buffer
-//   - 4096 bytes  -- .NET's BufferedStream default buffer, page size on most systems
-//   - 8192 bytes  -- Okio Segment.SIZE (used by Android's OkHttp fork), doubled StreamReader
-//
-// The intent is to catch buffer-mismatch stalls where the caller-side read buffer is
-// smaller than an intermediate wrapping layer's buffer, causing the intermediate layer
-// to over-drain the underlying stream and force an extra blocking read.
+// Sizes near the power-of-two boundaries matter because most stream-wrapping layers
+// choose buffer sizes at powers of two (1 KiB, 4 KiB, 8 KiB, ...); the +/-1 probes
+// catch sharp transitions we've observed in this class of bug -- sizes right below
+// a runtime buffer boundary stalling while sizes right at or above it don't.
 //
 // Sizes here are of the data string only; wire size = len("data: ") + size + len("\n\n").
-var payloadSizeSweep = []int{
-	1,
-	128,
-	512,
-	1023, 1024, 1025,
-	2048,
-	3999, 4094, 4096, 4098,
-	6144,
-	8189, 8192, 8195,
-	12288,
-	16384,
-	32768,
-	65536,
-	262144,
-	1048576,
+var payloadSizeSweep = generatePayloadSweep() //nolint:gochecknoglobals
+
+func generatePayloadSweep() []int {
+	seen := make(map[int]bool)
+	var sizes []int
+	add := func(n int) {
+		if n <= 0 || seen[n] {
+			return
+		}
+		seen[n] = true
+		sizes = append(sizes, n)
+	}
+	// 2^0 = 1 through 2^27 = 128 MiB
+	for i := 0; i <= 27; i++ {
+		pow := 1 << i
+		add(pow - 1)
+		add(pow)
+		add(pow + 1)
+	}
+	sort.Ints(sizes)
+	return sizes
 }
 
-// payloadArrivalTimeout is how long we wait for the test service to report the event.
-// Deliberately shorter than the default awaitMessageTimeout so that stalls fail fast
-// rather than eating the full default. For localhost test services this is more than
-// enough headroom; for very slow environments (real-device testing) it may need to
-// grow, but any stall of the class we're looking for (60+ seconds) will still trip it.
-const payloadArrivalTimeout = 3 * time.Second
+// timeoutForSize returns how long to wait for a payload of the given size to be delivered.
+//
+// A generous base timeout plus a per-byte allowance keeps the timeout tight enough to
+// catch stalls (which manifest as 60+ second waits) while allowing legitimate transfer
+// time for large payloads on modest connections. For a 128 MiB payload at the assumed
+// 5 MiB/s throughput, the timeout is ~31 seconds -- comfortably shorter than the 60+
+// second stall it is designed to catch.
+func timeoutForSize(size int) time.Duration {
+	const base = 5 * time.Second
+	const bytesPerSecond = 5 * 1024 * 1024 // 5 MiB/s allowance beyond base
+	return base + time.Duration(size)*time.Second/bytesPerSecond
+}
 
 // DoPayloadSizeStressTests sends events at a variety of payload sizes to catch buffer-mismatch
 // stalls in SSE client implementations. This covers a class of bug where the client's read
@@ -57,8 +68,9 @@ const payloadArrivalTimeout = 3 * time.Second
 //  2. Some SSE implementations may have latent buffer-mismatch behavior that isn't
 //     immediately fixable, and we don't want their existing CI to fail on adoption.
 //     Teams opt in by declaring the capability once they've validated the sweep.
-//  3. The largest sizes (1 MiB) may exceed reasonable defaults for some environments;
-//     opting in signals that the test service is prepared to handle them.
+//  3. The largest sizes (up to 128 MiB) may exceed reasonable memory/bandwidth
+//     defaults for some test environments; opting in signals that the test service
+//     is prepared to handle them.
 func DoPayloadSizeStressTests(t *ldtest.T) {
 	t.RequireCapability("payload-size-stress-testable")
 
@@ -68,7 +80,7 @@ func DoPayloadSizeStressTests(t *ldtest.T) {
 			_, stream, client := NewStreamAndSSEClient(t)
 			data := strings.Repeat("x", size)
 			stream.Send("data: " + data + "\n\n")
-			actual := client.RequireEventWithin(t, payloadArrivalTimeout)
+			actual := client.RequireEventWithin(t, timeoutForSize(size))
 			// Avoid printing megabytes of data on failure.
 			if actual.Data != data {
 				assert.Failf(t, "payload data did not match",

--- a/ssetests/tests_payload_sizes.go
+++ b/ssetests/tests_payload_sizes.go
@@ -47,14 +47,21 @@ func generatePayloadSweep() []int {
 
 // timeoutForSize returns how long to wait for a payload of the given size to be delivered.
 //
-// A generous base timeout plus a per-byte allowance keeps the timeout tight enough to
-// catch stalls (which manifest as 60+ second waits) while allowing legitimate transfer
-// time for large payloads on modest connections. For a 128 MiB payload at the assumed
-// 5 MiB/s throughput, the timeout is ~31 seconds -- comfortably shorter than the 60+
-// second stall it is designed to catch.
+// Constants were calibrated empirically against an Android emulator's adb-tunneled
+// throughput (~3 MiB/s round-trip observed). Prior values of base=5s, rate=5 MiB/s were
+// tuned for localhost throughput and were too tight for larger payloads on realistic
+// mobile/emulator infrastructure -- they timed out at 64 MiB (17.8s allowed) and 128 MiB
+// (30.6s allowed) even for correct implementations.
+//
+// Current values give ~10s for small payloads (well under the 60+ second stall the
+// harness is designed to catch) and ~74s for 128 MiB (comfortably above what the
+// emulator needs to transfer at ~3 MiB/s round-trip). At sizes that large, the
+// buffer-mismatch stall pattern can't manifest anyway -- TCP frames arrive continuously
+// -- so the timeout crossing the ~60s stall boundary at the top end does not reduce
+// the sweep's ability to catch the class of bug it targets.
 func timeoutForSize(size int) time.Duration {
-	const base = 5 * time.Second
-	const bytesPerSecond = 5 * 1024 * 1024 // 5 MiB/s allowance beyond base
+	const base = 10 * time.Second
+	const bytesPerSecond = 2 * 1024 * 1024 // 2 MiB/s effective allowance (~1.5x safety over observed emulator throughput)
 	return base + time.Duration(size)*time.Second/bytesPerSecond
 }
 

--- a/ssetests/testsuite.go
+++ b/ssetests/testsuite.go
@@ -10,6 +10,7 @@ var AllCapabilities = []string{ //nolint:gochecknoglobals
 	"comments",
 	"headers",
 	"last-event-id",
+	"payload-size-stress-testable",
 	"post",
 	"read-timeout",
 	"report",
@@ -35,6 +36,7 @@ func RunTestSuite(
 		t.Run("comments", DoCommentTests)
 		t.Run("linefeeds", DoLinefeedTests)
 		t.Run("HTTP behavior", DoHTTPBehaviorTests)
+		t.Run("payload size stress", DoPayloadSizeStressTests)
 		t.Run("reconnection", DoReconnectionTests)
 	})
 }


### PR DESCRIPTION
## Summary

Adds an opt-in contract-test suite that sweeps SSE `data:` payload sizes across common buffer-size boundaries (1 KiB, 4 KiB, 8 KiB, plus larger sizes up to 1 MiB), specifically to catch buffer-mismatch stalls in SSE client implementations. Gated behind a new capability so existing SDK contract-test runs stay green — teams opt in once they've validated the sweep against their implementation.

## Motivation

A LaunchDarkly customer running the .NET client SDK on MAUI Android reported streaming responses arriving 60–90 seconds after the server sent them. Investigation traced this to `Xamarin.Android.Net.AndroidMessageHandler` silently wrapping the response body in a `BufferedStream` with a 4096-byte default buffer. When the caller (in this case, `LaunchDarkly.EventSource`) used a 1024-byte `StreamReader`, the `BufferedStream` engaged its buffered path, over-drained the underlying Java `InputStream`, then blocked on a subsequent read waiting for the next HTTP chunk — which on an idle SSE keepalive-driven connection doesn't arrive until the next server-side heartbeat (~60 seconds).

The failure zone is narrow (roughly 1 KiB – 4 KiB payloads with a 1 KiB caller buffer). It's structurally invisible to the existing 5 MiB / 10 MiB payload tests because larger payloads span enough TCP frames that the underlying stream never goes idle between reads. Only sweeping through sizes in the sub-buffer-size range surfaces the class of bug.

## What's in this PR

- New capability `payload-size-stress-testable` documented in `docs/optional_features.md`.
- New test suite `tests_payload_sizes.go` sweeping 20 payload sizes clustered around 1 KiB, 4 KiB, and 8 KiB boundaries, plus exponential expansion up to 1 MiB.
- New `SSEClient.RequireEventWithin(t, timeout)` helper so payload-size tests fail fast (3 s) on stalls rather than eating the default 5-second `awaitMessageTimeout`. Existing callers of `RequireEvent(t)` are unaffected.
- Wiring in `ssetests/testsuite.go` — new capability added to `AllCapabilities`, new suite dispatched from `RunTestSuite`.

## Opt-in rationale

Two reasons the capability is opt-in rather than a spec-conformance requirement:

1. This is a stress / robustness test, not a spec-conformance check. An SSE implementation can be fully valid without passing it.
2. Some implementations may have latent buffer-mismatch behavior that isn't immediately fixable — we don't want their existing CI turning red on adoption of this change. Teams opt in by declaring the capability once they've validated the sweep.

Once .NET's `LaunchDarkly.EventSource` ships its buffer-size fix and validates against this sweep, we'll declare the capability on the .NET test service. Other SSE-consuming SDK teams can follow at their own pace.

## Test plan

- [x] `go build ./...` clean
- [x] Manual verification: harness with this sweep run against unfixed `LaunchDarkly.EventSource` .NET test service on Android emulator — confirm the small-payload cases fail with the expected stall signature
- [ ] Manual verification: same harness run against fixed `LaunchDarkly.EventSource` — confirm all sizes pass
- [ ] Downstream: fix PR against `launchdarkly/dotnet-eventsource` bumping the `StreamReader` buffer from 1024 to 8192 bytes (separate PR)

## Related

- Investigation writeup and reproduction data lives in the LaunchDarkly .NET SDK team's SDK-2755 ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the contract-test harness and docs; the new suite is opt-in via a capability flag and does not alter default test runs for existing SDK services.
> 
> **Overview**
> Adds an **opt-in** contract-test capability **`payload-size-stress-testable`** and a **payload size stress** suite aimed at buffer-mismatch read stalls (caller buffer vs intermediate `BufferedStream`-style layers).
> 
> The harness sweeps **`data:`** payload lengths at every power of two from 1 byte through **128 MiB**, plus ±1 byte around each boundary, and asserts each event is reported within a **size-scaled timeout** (`timeoutForSize`). Documentation in `docs/optional_features.md` explains the motivation and why teams must declare the capability before CI runs the sweep.
> 
> **`SSEClient.RequireEventWithin`** is added so these cases can use shorter or longer waits than the default `RequireEvent` timeout without changing existing callers. **`AllCapabilities`** and **`RunTestSuite`** register the new capability and dispatch **`DoPayloadSizeStressTests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1472e3b133118d77640d7d8fbe11f55dd7d0399e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->